### PR TITLE
Switch to env in hashbang

### DIFF
--- a/httpstat.sh
+++ b/httpstat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 print_help() {
     cat <<'END'


### PR DESCRIPTION
This allows to use `bash` that is first in `$PATH`. This case is quite common on macOS where system's `bash` is ancient and brew installs fresh one into `/usr/local/bin/bash`.